### PR TITLE
Add the Qt5 SerialPort module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ ADD_LIBRARY(coreplugins SHARED
   ${PLUGIN_SOURCES}
   ${PLUGIN_HEADERS}
 )
-qt5_use_modules(coreplugins Widgets Location Sensors Feedback SystemInfo Contacts Multimedia Quick MultimediaWidgets)
+qt5_use_modules(coreplugins Widgets Location Sensors Feedback SystemInfo Contacts Multimedia Quick MultimediaWidgets SerialPort)
 
 target_link_libraries(cordova-ubuntu cordovaubuntuplugin)
 target_link_libraries(coreplugins cordovaubuntuplugin ${PLUGIN_DEPS_LIBRARIES})


### PR DESCRIPTION
The "cordovarduino" plugin provides USB/serial support to cordova for the Android platform. I submitted https://github.com/xseignard/cordovarduino/pull/25 to add ubuntu platform support to cordovarduino, but it requires this minor change to cordova-ubuntu to enable the Qt5 SerialPort module.
