### PR TITLE
Success callback id and error callback id is injected by exec.js and …

### DIFF
--- a/CordovaUbuntu/cordova_wrapper.js
+++ b/CordovaUbuntu/cordova_wrapper.js
@@ -46,6 +46,10 @@ function execMethod(pluginName, functionName, params) {
     if (typeof pluginObjects[pluginName][functionName] != "function")
         return false;
 
+    //  Extract the success callback id and failure callback ids sent by the plugin side
+    var scId = params.shift();
+    var ecId = params.shift();
+
     pluginObjects[pluginName][functionName].apply(this, params);
     return true;
 }


### PR DESCRIPTION
…needs to be extracted on the other side

This to prevent the native method from getting the callback ids as its first and second argument.
As the callbacks has not been implemented in the platform yet, the ids are not actually used for anything.