### PR TITLE
Cb 9694 - Add support for HTTP urls

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -56,6 +56,7 @@ exports.createProject = function(projectPath, packageName, projectName) {
 
     shell.mkdir(path.join(projectPath, 'www'));
     shell.cp(path.join(ROOT, 'www', 'cordova.js'), path.join(projectPath, 'www'));
+    shell.cp('-rf', path.join(ROOT, 'cordova-js-src'), path.join(projectPath, 'platform_www'));
 
     shell.cp('-r', path.join(ROOT, 'xml/config.xml'), projectPath);
 } 

--- a/src/cordova.cpp
+++ b/src/cordova.cpp
@@ -34,9 +34,10 @@ Cordova::Cordova(const QDir &wwwDir, QQuickItem *item, QObject *parent)
         _mainUrl = QString(_config.content());
     } else if (!_www.exists(_config.content())) {
         qCritical() << _config.content() << "does not exist";
-        _mainUrl = QUrl::fromUserInput(_www.absoluteFilePath(_config.content()))
-	  .toString();
     }
+
+    _mainUrl = QUrl::fromUserInput(_www.absoluteFilePath(_config.content()))
+      .toString();
 
     qDebug() << "Main URL: " << _mainUrl;
 }

--- a/src/cordova.cpp
+++ b/src/cordova.cpp
@@ -25,16 +25,20 @@
 #include <QQmlContext>
 
 Cordova::Cordova(const QDir &wwwDir, QQuickItem *item, QObject *parent)
-    : QObject(parent), _item(item), _www(wwwDir), _config(_www.absoluteFilePath("../config.xml")) {
+    : QObject(parent), _item(item), _www(wwwDir),
+      _config(_www.absoluteFilePath("../config.xml")) {
 
-    qDebug() << "Using" << _www.absolutePath() << "as working dir";
+    qDebug() << "Work directory: " << _www.absolutePath();
 
-    if (!_www.exists(_config.content()))
-        qCritical() << _config.content() << "does not exists";
+    if (_config.content().contains(QRegExp("^(http://)"))) {
+        _mainUrl = QString(_config.content());
+    } else if (!_www.exists(_config.content())) {
+        qCritical() << _config.content() << "does not exist";
+        _mainUrl = QUrl::fromUserInput(_www.absoluteFilePath(_config.content()))
+	  .toString();
+    }
 
-    _mainUrl = QUrl::fromUserInput(_www.absoluteFilePath(_config.content())).toString();
-
-    qDebug() << _mainUrl;
+    qDebug() << "Main URL: " << _mainUrl;
 }
 
 void Cordova::appLoaded() {
@@ -79,8 +83,8 @@ QString Cordova::getSplashscreenPath() {
 }
 
 const CordovaInternal::Config& Cordova::config() const {
-    return _config;
-}
+    return _config;}
+
 
 void Cordova::initPlugins() {
     QList<QDir> searchPath = {get_app_dir()};

--- a/src/cordova.cpp
+++ b/src/cordova.cpp
@@ -34,10 +34,10 @@ Cordova::Cordova(const QDir &wwwDir, QQuickItem *item, QObject *parent)
         _mainUrl = QString(_config.content());
     } else if (!_www.exists(_config.content())) {
         qCritical() << _config.content() << "does not exist";
+    } else {
+        _mainUrl = QUrl::fromUserInput(_www.absoluteFilePath(_config.content()))
+	  .toString();
     }
-
-    _mainUrl = QUrl::fromUserInput(_www.absoluteFilePath(_config.content()))
-      .toString();
 
     qDebug() << "Main URL: " << _mainUrl;
 }

--- a/tests/config.xml
+++ b/tests/config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<widget xmlns     = "http://www.w3.org/ns/widgets"
+        id        = "io.cordova.helloCordova"
+        version   = "2.0.0">
+    <name>Hello Cordova</name>
+
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+
+    <author href="http://cordova.io" email="dev@cordova.apache.org">
+        Apache Cordova Team
+    </author>
+
+    <access origin="*"/>
+
+    <content src="http://192.168.1.35:8100" original-src="index.html"/>
+
+    <preference name="loglevel" value="DEBUG" />
+    <!--
+      <preference name="splashscreen" value="resourceName" />
+      <preference name="backgroundColor" value="0xFFF" />
+      <preference name="loadUrlTimeoutValue" value="20000" />
+      <preference name="InAppBrowserStorageEnabled" value="true" />
+      <preference name="disallowOverscroll" value="true" />
+    -->
+</widget>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -22,6 +22,7 @@
 
 #include "../src/cplugin.h"
 #include "../src/cordova_config.hpp"
+#include "../src/cordova.h"
 
 TEST(CordovaInternal, format_double_int_int) {
     auto t = std::make_tuple(1.1, 2, 3);
@@ -82,6 +83,19 @@ TEST(Cordova, WhiteList) {
     timer.start(1000);
 
     EXPECT_EQ(app.exec(), 0);
+}
+
+TEST(Cordova, loadURLSupport) {
+
+    CordovaInternal::Config config("config.xml");    
+    QDir www("www");
+    QQuickItem item;;
+
+    Cordova *cordova = new Cordova(www, &item, NULL);
+
+    EXPECT_TRUE(cordova != NULL);
+    EXPECT_STREQ("http://192.168.1.35:8100",
+		 cordova->mainUrl().toLatin1().data());
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
The cordova-ubuntu container currently does not support loading the app from a network URL, only local file URLs. This prevents features like livereloading to work.